### PR TITLE
fixed loading config file twice

### DIFF
--- a/src/Holycode.Configuration/Holycode.Configuration.csproj
+++ b/src/Holycode.Configuration/Holycode.Configuration.csproj
@@ -7,8 +7,10 @@
 		<Description>Tools for managing configuration</Description>
 		<AssemblyName>Holycode.Configuration</AssemblyName>
 		<PackageId>Holycode.Configuration</PackageId>
-		<Version>4.1.0</Version>
+		<Version>4.1.1</Version>
 		<PackageReleaseNotes>
+			v 4.1.1 - prevent double load of env.default.json
+					  when env.json was not present
 			v 4.1.0 - loading additional config files: per build type (#32358)
 			v 4.0.3 - more depedency fixes, for netstandard2.1 and net6.0
 			v 4.0.2 - depend on Microsoft.Extensions.* v 2.0 when targeting net461

--- a/src/Holycode.Configuration/Infrastructure/Conventions/EnvJsonConvention.cs
+++ b/src/Holycode.Configuration/Infrastructure/Conventions/EnvJsonConvention.cs
@@ -87,7 +87,11 @@ namespace Holycode.Configuration.Conventions
 
                     AddDefaultFiles(dir, mainConfigNameNoExt, builder);
 
-                    AddMainFile(path, builder, IsMainConfigOptional);
+                    string fileName = Path.GetFileName(path);
+                    if (fileName != "env.default.json")
+                    {
+                        AddMainFile(path, builder, IsMainConfigOptional);
+                    }
 
                     string env = GetEnvName(builder);
                     builder.Set(EnvironmentNameKey, env);


### PR DESCRIPTION
configuration file env.default.json was loaded twice when no env.json file was present